### PR TITLE
Fix/outlet metric unique id collision

### DIFF
--- a/custom_components/middle_atlantic_racklink/__init__.py
+++ b/custom_components/middle_atlantic_racklink/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     Platform,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_registry as er
@@ -123,6 +123,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
+    # Migrate legacy outlet-metric unique IDs now that the serial is known
+    await _async_migrate_outlet_metric_unique_ids(
+        hass, entry, controller.pdu_serial
+    )
+
     # Set up platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -141,6 +146,65 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     return True
+
+
+# Suffixes of the outlet-metric sensors that historically used a
+# never-populated "device_id" and collapsed to the literal "unknown_" prefix.
+_LEGACY_OUTLET_METRIC_PREFIX = "unknown_"
+_OUTLET_METRIC_SUFFIXES = ("_power", "_energy", "_current", "_voltage")
+
+
+async def _async_migrate_outlet_metric_unique_ids(
+    hass: HomeAssistant, entry: ConfigEntry, serial: str | None
+) -> None:
+    """Rename legacy ``unknown_<outlet>_<metric>`` unique IDs to use the serial.
+
+    Earlier versions built the outlet power/energy/current/voltage unique IDs
+    from a ``device_id`` key that was never set, so they all collapsed to
+    ``unknown_<outlet>_<metric>``. With more than one PDU these collided and the
+    second PDU's entities were dropped. The IDs are now namespaced by
+    ``pdu_serial``; rename any pre-existing entities on this entry so their
+    history carries over instead of orphaning them.
+    """
+    if not serial or serial == "unknown":
+        # Without a usable serial the new ID would be no better than the old one.
+        return
+
+    registry = er.async_get(hass)
+
+    @callback
+    def _migrate(entity: er.RegistryEntry) -> dict[str, str] | None:
+        old_unique_id = entity.unique_id
+        if not old_unique_id.startswith(_LEGACY_OUTLET_METRIC_PREFIX):
+            return None
+        if not old_unique_id.endswith(_OUTLET_METRIC_SUFFIXES):
+            return None
+
+        # "unknown_7_voltage" -> "<serial>_7_voltage"
+        suffix = old_unique_id[len(_LEGACY_OUTLET_METRIC_PREFIX) :]
+        new_unique_id = f"{serial}_{suffix}"
+        if new_unique_id == old_unique_id:
+            return None
+
+        # Don't clobber an entity that already owns the target unique ID.
+        if registry.async_get_entity_id(
+            entity.domain, entity.platform, new_unique_id
+        ):
+            _LOGGER.warning(
+                "Cannot migrate unique_id %s to %s; target already exists",
+                old_unique_id,
+                new_unique_id,
+            )
+            return None
+
+        _LOGGER.info(
+            "Migrating outlet metric unique_id %s -> %s",
+            old_unique_id,
+            new_unique_id,
+        )
+        return {"new_unique_id": new_unique_id}
+
+    await er.async_migrate_entries(hass, entry.entry_id, _migrate)
 
 
 async def async_update_options(

--- a/custom_components/middle_atlantic_racklink/sensor.py
+++ b/custom_components/middle_atlantic_racklink/sensor.py
@@ -343,7 +343,7 @@ class RacklinkOutletPowerSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._outlet_id = outlet_id
         self._attr_unique_id = (
-            f"{coordinator.data.get('device_id', 'unknown')}_{outlet_id}_power"
+            f"{coordinator.controller.pdu_serial}_{outlet_id}_power"
         )
 
         # Get outlet name for entity naming and always include outlet number
@@ -561,7 +561,7 @@ class RacklinkOutletEnergySensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._outlet_id = outlet_id
         self._attr_unique_id = (
-            f"{coordinator.data.get('device_id', 'unknown')}_{outlet_id}_energy"
+            f"{coordinator.controller.pdu_serial}_{outlet_id}_energy"
         )
 
         label = (
@@ -609,7 +609,7 @@ class RacklinkOutletCurrentSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._outlet_id = outlet_id
         self._attr_unique_id = (
-            f"{coordinator.data.get('device_id', 'unknown')}_{outlet_id}_current"
+            f"{coordinator.controller.pdu_serial}_{outlet_id}_current"
         )
 
         label = (
@@ -654,7 +654,7 @@ class RacklinkOutletVoltageSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._outlet_id = outlet_id
         self._attr_unique_id = (
-            f"{coordinator.data.get('device_id', 'unknown')}_{outlet_id}_voltage"
+            f"{coordinator.controller.pdu_serial}_{outlet_id}_voltage"
         )
 
         label = (

--- a/tests/test_integration_setup.py
+++ b/tests/test_integration_setup.py
@@ -3,9 +3,13 @@
 import pytest
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.middle_atlantic_racklink import DOMAIN
+from custom_components.middle_atlantic_racklink import (
+    DOMAIN,
+    _async_migrate_outlet_metric_unique_ids,
+)
 from custom_components.middle_atlantic_racklink.const import (
     CONNECTION_TYPE_AUTO,
     CONNECTION_TYPE_REDFISH,
@@ -228,3 +232,68 @@ class TestIntegrationSetup:
 
         # Verify suggested area
         assert device_info.get("suggested_area") == "Electrical"
+
+
+class TestOutletMetricUniqueIdMigration:
+    """Tests for the legacy outlet-metric unique ID migration."""
+
+    def _add_entry(self, hass: HomeAssistant) -> MockConfigEntry:
+        entry = MockConfigEntry(domain=DOMAIN, entry_id="migrate_entry")
+        entry.add_to_hass(hass)
+        return entry
+
+    async def test_renames_legacy_unknown_ids(self, hass: HomeAssistant) -> None:
+        """Legacy ``unknown_<outlet>_<metric>`` IDs are renamed to the serial."""
+        entry = self._add_entry(hass)
+        registry = er.async_get(hass)
+        entity = registry.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "unknown_7_voltage",
+            config_entry=entry,
+        )
+
+        await _async_migrate_outlet_metric_unique_ids(hass, entry, "SERIAL-A")
+
+        assert (
+            registry.async_get(entity.entity_id).unique_id == "SERIAL-A_7_voltage"
+        )
+
+    async def test_skips_when_target_exists(self, hass: HomeAssistant) -> None:
+        """A collision with an existing serial-based ID leaves the legacy one."""
+        entry = self._add_entry(hass)
+        registry = er.async_get(hass)
+        legacy = registry.async_get_or_create(
+            "sensor", DOMAIN, "unknown_7_voltage", config_entry=entry
+        )
+        registry.async_get_or_create(
+            "sensor", DOMAIN, "SERIAL-A_7_voltage", config_entry=entry
+        )
+
+        await _async_migrate_outlet_metric_unique_ids(hass, entry, "SERIAL-A")
+
+        assert registry.async_get(legacy.entity_id).unique_id == "unknown_7_voltage"
+
+    async def test_no_serial_is_noop(self, hass: HomeAssistant) -> None:
+        """Without a usable serial nothing is renamed."""
+        entry = self._add_entry(hass)
+        registry = er.async_get(hass)
+        entity = registry.async_get_or_create(
+            "sensor", DOMAIN, "unknown_7_voltage", config_entry=entry
+        )
+
+        await _async_migrate_outlet_metric_unique_ids(hass, entry, "unknown")
+
+        assert registry.async_get(entity.entity_id).unique_id == "unknown_7_voltage"
+
+    async def test_unrelated_ids_untouched(self, hass: HomeAssistant) -> None:
+        """IDs that aren't legacy outlet metrics are left alone."""
+        entry = self._add_entry(hass)
+        registry = er.async_get(hass)
+        switch = registry.async_get_or_create(
+            "switch", DOMAIN, "unknown_outlet_7", config_entry=entry
+        )
+
+        await _async_migrate_outlet_metric_unique_ids(hass, entry, "SERIAL-A")
+
+        assert registry.async_get(switch.entity_id).unique_id == "unknown_outlet_7"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,6 +3,10 @@
 from custom_components.middle_atlantic_racklink.sensor import (
     RacklinkCurrentSensor,
     RacklinkFrequencySensor,
+    RacklinkOutletCurrentSensor,
+    RacklinkOutletEnergySensor,
+    RacklinkOutletPowerSensor,
+    RacklinkOutletVoltageSensor,
     RacklinkPowerSensor,
     RacklinkVoltageSensor,
 )
@@ -102,3 +106,38 @@ async def test_sensor_error_handling(controller):
 
     # Check state
     assert sensor.native_value is None
+
+
+def _outlet_coordinator(serial: str) -> MagicMock:
+    """Build a mock coordinator for an outlet metric sensor."""
+    coordinator = MagicMock()
+    coordinator.controller.pdu_serial = serial
+    # Real dict so the chained .get(...) calls in __init__ behave correctly.
+    coordinator.data = {}
+    return coordinator
+
+
+@pytest.mark.parametrize(
+    ("sensor_cls", "suffix"),
+    [
+        (RacklinkOutletPowerSensor, "power"),
+        (RacklinkOutletEnergySensor, "energy"),
+        (RacklinkOutletCurrentSensor, "current"),
+        (RacklinkOutletVoltageSensor, "voltage"),
+    ],
+)
+def test_outlet_metric_unique_id_distinct_per_pdu(sensor_cls, suffix):
+    """Outlet metric unique IDs must be namespaced by the PDU serial.
+
+    Regression test: previously these IDs used a never-populated
+    ``device_id`` key and fell back to the literal ``"unknown"``, so two
+    PDUs produced identical IDs (e.g. ``unknown_7_voltage``) and the second
+    PDU's outlet metric entities were dropped as duplicates.
+    """
+    pdu_a = sensor_cls(_outlet_coordinator("SERIAL-A"), 7)
+    pdu_b = sensor_cls(_outlet_coordinator("SERIAL-B"), 7)
+
+    assert pdu_a.unique_id == f"SERIAL-A_7_{suffix}"
+    assert pdu_b.unique_id == f"SERIAL-B_7_{suffix}"
+    assert pdu_a.unique_id != pdu_b.unique_id
+    assert "unknown" not in pdu_a.unique_id


### PR DESCRIPTION
# Pull Request

## Description
The unique ids for outlet metrics (energy, voltage, etc) were based on `coordinator.data.get('device_id', 'unknown')`, but it appears that `device_id` is never set, so the IDs ended up like "unknown_7_voltage". adding multiple devices caused conflicts, so those entities were skipped in subsequent devices.

example logs:

```
2026-06-25 15:05:09.476 ERROR (MainThread) [homeassistant.components.sensor] Platform middle_atlantic_racklink does not generate unique IDs. ID unknown_8_power already exists - ignoring sensor.electrical_racklink_pdu_1_outlet_8_power
2026-06-25 15:05:09.476 ERROR (MainThread) [homeassistant.components.sensor] Platform middle_atlantic_racklink does not generate unique IDs. ID unknown_8_energy already exists - ignoring sensor.electrical_racklink_pdu_1_outlet_8_energy
2026-06-25 15:05:09.476 ERROR (MainThread) [homeassistant.components.sensor] Platform middle_atlantic_racklink does not generate unique IDs. ID unknown_8_current already exists - ignoring sensor.electrical_racklink_pdu_1_outlet_8_current
2026-06-25 15:05:09.476 ERROR (MainThread) [homeassistant.components.sensor] Platform middle_atlantic_racklink does not generate unique IDs. ID unknown_8_voltage already exists - ignoring sensor.electrical_racklink_pdu_1_outlet_8_voltage
```

4 entities per outlet, 8 outlets == 32 entities. the first P920R I add has 75 entities, the second only has 43, so this lines up.

the fix is to use `coordinator.controller.pdu_serial`, which all the other entities use.

I also included a migration to fix the old `unknown_*` ids.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement
- [ ] Test improvement

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this with actual hardware (if applicable)

## Connection Types Tested
- [x] Redfish HTTPS
- [ ] Redfish HTTP
- [ ] Telnet/Binary
- [ ] Hybrid Mode
- [ ] Auto-detection

## Device Models Tested
- [x] RLNK-P920R
- [ ] RLNK-P415
- [ ] Other: ___________

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Related Issues
Fixes #5 