### PR TITLE
Clarify per-outlet load shedding sensor name

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The polling interval can be tuned under the integration's **Configure** menu (5â
 - **Switches**: one per outlet (device class *outlet*), with outlet metadata (power-on delays, rated current) as attributes; plus **Load shedding** and **Outlet sequence** switches when a telnet channel is available
 - **Sensors** (PDU): voltage, current, power, apparent power, power factor, frequency, energy
 - **Sensors** (per outlet, Redfish): power, energy, current, voltage (voltage is disabled by default since it duplicates the mains voltage)
-- **Binary sensors**: surge protection problem, per-outlet non-critical (sheds on load shedding) flag
+- **Binary sensors**: surge protection problem, and a per-outlet "powers off during load shedding" flag (on = the PDU has marked the outlet non-critical, so it sheds when load shedding is activated)
 - **Buttons**: cycle per outlet, cycle all outlets
 - **Numbers**: outlet sequence delay (seconds between outlets during a power-on sequence)
 

--- a/custom_components/middle_atlantic_racklink/strings.json
+++ b/custom_components/middle_atlantic_racklink/strings.json
@@ -89,7 +89,7 @@
     },
     "binary_sensor": {
       "surge_protection": { "name": "Surge protection" },
-      "outlet_non_critical": { "name": "Outlet {outlet_number} sheds on load shedding" }
+      "outlet_non_critical": { "name": "Outlet {outlet_number} powers off during load shedding" }
     },
     "switch": {
       "outlet": { "name": "Outlet {outlet_number}" },

--- a/custom_components/middle_atlantic_racklink/translations/en.json
+++ b/custom_components/middle_atlantic_racklink/translations/en.json
@@ -89,7 +89,7 @@
     },
     "binary_sensor": {
       "surge_protection": { "name": "Surge protection" },
-      "outlet_non_critical": { "name": "Outlet {outlet_number} sheds on load shedding" }
+      "outlet_non_critical": { "name": "Outlet {outlet_number} powers off during load shedding" }
     },
     "switch": {
       "outlet": { "name": "Outlet {outlet_number}" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The per-outlet binary sensor "Outlet N sheds on load shedding: On" was easy to misread as "load shedding is currently on", when it actually reports the outlet's non-critical *configuration* — i.e. whether that outlet will be powered off when load shedding activates.

Renamed the sensor to **"Outlet N powers off during load shedding"** in `strings.json` / `translations/en.json`, and clarified the README entity description. The translation key and unique IDs are unchanged, so no entity migration is needed; existing entities pick up the new name automatically (unless manually renamed).

## Testing

- All 71 tests pass
- hassfest validation passes against the updated translation files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2608-ead6-706d-93fb-2c66d8a84742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2608-ead6-706d-93fb-2c66d8a84742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

