### PR TITLE
Add bundled dashboard cards for PDU and sequencer control (v1.2.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
           cache: "pip"
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Hassfest validation
         uses: home-assistant/actions/hassfest@master
@@ -81,10 +81,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
           cache: "pip"
@@ -51,7 +51,7 @@ jobs:
           zip -r ../../middle_atlantic_racklink.zip .
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: "v${{ steps.get_version.outputs.VERSION }}"
           files: middle_atlantic_racklink.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-07-03
+
+### Added
+- Bundled custom dashboard cards, loaded automatically (no manual resource setup):
+  - `custom:racklink-pdu-card`: PDU overview with live power metrics and per-outlet switch/cycle controls
+  - `custom:racklink-sequencer-card`: outlet sequencing, sequence delay, and load shedding management
+- `outlet_number` attribute on per-outlet sensors, binary sensors, and cycle buttons (used by the cards to group entities per outlet)
+
+### Changed
+- Renamed the per-outlet "sheds on load shedding" sensor to "powers off during load shedding" to avoid misreading it as the load shedding mode state
+- CI/release workflows use Node 24 action runtimes (`actions/checkout@v6`, `actions/setup-python@v6`, `softprops/action-gh-release@v3`)
+
 ## [1.1.0] - 2026-07-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The polling interval can be tuned under the integration's **Configure** menu (5â
 - **Switches**: one per outlet (device class *outlet*), with outlet metadata (power-on delays, rated current) as attributes; plus **Load shedding** and **Outlet sequence** switches when a telnet channel is available
 - **Sensors** (PDU): voltage, current, power, apparent power, power factor, frequency, energy
 - **Sensors** (per outlet, Redfish): power, energy, current, voltage (voltage is disabled by default since it duplicates the mains voltage)
-- **Binary sensors**: surge protection problem, per-outlet non-critical (sheds on load shedding) flag
+- **Binary sensors**: surge protection problem, and a per-outlet "powers off during load shedding" flag (on = the PDU has marked the outlet non-critical, so it sheds when load shedding is activated)
 - **Buttons**: cycle per outlet, cycle all outlets
 - **Numbers**: outlet sequence delay (seconds between outlets during a power-on sequence)
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,27 @@ The polling interval can be tuned under the integration's **Configure** menu (5â
 
 The PDU **Energy** sensor and the per-outlet **Outlet N energy** sensors are total-increasing kWh sensors, so they can be added to the Home Assistant Energy dashboard under **Individual devices** to track rack-level and per-device consumption. The power sensors (W) feed the power graphs and can drive automations (e.g. shut down a server when its outlet draws less than a threshold).
 
+## Dashboard cards
+
+The integration bundles two custom Lovelace cards and registers them automatically â€” no manual resource configuration or extra HACS frontend install is needed. Both appear in the card picker ("RackLink PDU" and "RackLink sequencer") with a visual editor, or can be added via YAML:
+
+```yaml
+type: custom:racklink-pdu-card
+device_id: YOUR_PDU_DEVICE_ID   # pick the device in the visual editor
+title: Rack PDU                 # optional
+```
+
+The **PDU card** shows live voltage, current, energy, and power factor chips with the total power headline, plus one row per outlet with its state, power draw, a cycle button, and an on/off toggle. Outlets marked non-critical are tagged "sheds".
+
+```yaml
+type: custom:racklink-sequencer-card
+device_id: YOUR_PDU_DEVICE_ID
+```
+
+The **sequencer card** manages power-on sequencing (enable/disable plus a delay stepper), load shedding (with the list of outlets that will power off), and a cycle-all-outlets action. Sequencing and load shedding rows appear only when the telnet vendor channel is available.
+
+Cards discover the PDU's entities through the device registry, so they keep working if you rename entities.
+
 ## Services
 
 All services target outlet switch entities of this integration:

--- a/custom_components/middle_atlantic_racklink/__init__.py
+++ b/custom_components/middle_atlantic_racklink/__init__.py
@@ -17,6 +17,8 @@ from .const import (
 from .controller.racklink_controller import RacklinkController
 from .coordinator import RacklinkCoordinator
 from datetime import timedelta
+from homeassistant.components.frontend import add_extra_js_url
+from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
@@ -28,10 +30,15 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.loader import async_get_integration
+from pathlib import Path
 
 import logging
 
 _LOGGER = logging.getLogger(__name__)
+
+CARDS_URL = f"/{DOMAIN}/racklink-cards.js"
+CARDS_PATH = Path(__file__).parent / "frontend" / "racklink-cards.js"
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -46,9 +53,20 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 RacklinkConfigEntry = ConfigEntry[RacklinkCoordinator]
 
 
-async def async_setup(_hass: HomeAssistant, _config: ConfigType) -> bool:
+async def async_setup(hass: HomeAssistant, _config: ConfigType) -> bool:
     """Set up the Middle Atlantic RackLink component."""
+    await _async_register_cards(hass)
     return True
+
+
+async def _async_register_cards(hass: HomeAssistant) -> None:
+    """Serve the bundled Lovelace cards and load them on every dashboard."""
+    await hass.http.async_register_static_paths(
+        [StaticPathConfig(CARDS_URL, str(CARDS_PATH), cache_headers=True)]
+    )
+    # Versioned query string busts browser caches on upgrades
+    integration = await async_get_integration(hass, DOMAIN)
+    add_extra_js_url(hass, f"{CARDS_URL}?v={integration.version}")
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: RacklinkConfigEntry) -> bool:

--- a/custom_components/middle_atlantic_racklink/binary_sensor.py
+++ b/custom_components/middle_atlantic_racklink/binary_sensor.py
@@ -153,6 +153,7 @@ class RacklinkOutletBinarySensor(RacklinkBinarySensorBase):
             f"{coordinator.controller.pdu_serial}_outlet_{outlet}_{description.key}"
         )
         self._attr_translation_placeholders = {"outlet_number": str(outlet)}
+        self._attr_extra_state_attributes = {"outlet_number": outlet}
 
     @property
     def is_on(self) -> Optional[bool]:

--- a/custom_components/middle_atlantic_racklink/button.py
+++ b/custom_components/middle_atlantic_racklink/button.py
@@ -113,6 +113,7 @@ class RacklinkOutletCycleButton(RacklinkButtonBase):
             f"{coordinator.controller.pdu_serial}_outlet_{outlet_number}_cycle"
         )
         self._attr_translation_placeholders = {"outlet_number": str(outlet_number)}
+        self._attr_extra_state_attributes = {"outlet_number": outlet_number}
 
     async def async_press(self) -> None:
         """Press the button."""

--- a/custom_components/middle_atlantic_racklink/frontend/racklink-cards.js
+++ b/custom_components/middle_atlantic_racklink/frontend/racklink-cards.js
@@ -1,0 +1,578 @@
+/**
+ * Custom Lovelace cards for the Middle Atlantic RackLink integration.
+ *
+ * Provides:
+ *   - custom:racklink-pdu-card       PDU overview with live metrics and
+ *                                    per-outlet switch/cycle controls.
+ *   - custom:racklink-sequencer-card Load shedding and outlet sequencing
+ *                                    management for a PDU.
+ *
+ * Both cards are configured with the PDU device (device_id) and discover
+ * the integration's entities automatically, so they keep working when
+ * entities are renamed.
+ */
+
+const DOMAIN = "middle_atlantic_racklink";
+
+/* ------------------------------------------------------------------ */
+/* Entity discovery helpers                                            */
+/* ------------------------------------------------------------------ */
+
+function deviceEntities(hass, deviceId) {
+  return Object.values(hass.entities || {}).filter(
+    (entry) =>
+      entry.device_id === deviceId &&
+      entry.platform === DOMAIN &&
+      !entry.hidden &&
+      !entry.disabled_by
+  );
+}
+
+function stateOf(hass, entry) {
+  return entry ? hass.states[entry.entity_id] : undefined;
+}
+
+function outletNumber(hass, entry) {
+  const state = stateOf(hass, entry);
+  const attr = state && state.attributes.outlet_number;
+  return attr === undefined ? null : Number(attr);
+}
+
+function classify(hass, entry) {
+  // Prefer the registry translation_key; fall back to attribute heuristics
+  // for older frontends that do not expose it.
+  if (entry.translation_key) return entry.translation_key;
+  const [domain] = entry.entity_id.split(".");
+  const state = stateOf(hass, entry);
+  const attrs = state ? state.attributes : {};
+  const outlet = attrs.outlet_number !== undefined;
+  if (domain === "switch") return outlet ? "outlet" : null;
+  if (domain === "button") return outlet ? "cycle_outlet" : "cycle_all_outlets";
+  if (domain === "sensor" && outlet) {
+    if (attrs.device_class === "power") return "outlet_power";
+    if (attrs.device_class === "energy") return "outlet_energy";
+    if (attrs.device_class === "current") return "outlet_current";
+    if (attrs.device_class === "voltage") return "outlet_voltage";
+  }
+  if (domain === "sensor") return attrs.device_class || null;
+  if (domain === "binary_sensor" && outlet) return "outlet_non_critical";
+  if (domain === "binary_sensor") return "surge_protection";
+  if (domain === "number") return "sequence_delay";
+  return null;
+}
+
+function collectModel(hass, deviceId) {
+  const model = {
+    pdu: {},
+    outlets: new Map(),
+    loadShedding: null,
+    sequence: null,
+    sequenceDelay: null,
+    cycleAll: null,
+    surgeProtection: null,
+  };
+  for (const entry of deviceEntities(hass, deviceId)) {
+    const key = classify(hass, entry);
+    if (!key) continue;
+    const outlet = outletNumber(hass, entry);
+    if (outlet !== null) {
+      if (!model.outlets.has(outlet)) model.outlets.set(outlet, {});
+      const bucket = model.outlets.get(outlet);
+      if (key === "outlet") bucket.switch = entry;
+      else if (key === "cycle_outlet") bucket.cycle = entry;
+      else if (key === "outlet_power") bucket.power = entry;
+      else if (key === "outlet_energy") bucket.energy = entry;
+      else if (key === "outlet_current") bucket.current = entry;
+      else if (key === "outlet_non_critical") bucket.nonCritical = entry;
+      continue;
+    }
+    if (key === "load_shedding") model.loadShedding = entry;
+    else if (key === "sequence") model.sequence = entry;
+    else if (key === "sequence_delay") model.sequenceDelay = entry;
+    else if (key === "cycle_all_outlets") model.cycleAll = entry;
+    else if (key === "surge_protection") model.surgeProtection = entry;
+    else model.pdu[key] = entry;
+  }
+  return model;
+}
+
+function fmt(hass, entry, digits) {
+  const state = stateOf(hass, entry);
+  if (!state || state.state === "unknown" || state.state === "unavailable") {
+    return null;
+  }
+  const value = Number(state.state);
+  const text = Number.isFinite(value)
+    ? value.toFixed(digits === undefined ? 1 : digits)
+    : state.state;
+  const unit = state.attributes.unit_of_measurement;
+  return unit ? `${text} ${unit}` : text;
+}
+
+function firstDeviceOfIntegration(hass) {
+  const entry = Object.values(hass.entities || {}).find(
+    (item) => item.platform === DOMAIN && item.device_id
+  );
+  return entry ? entry.device_id : "";
+}
+
+function deviceName(hass, deviceId) {
+  const device = (hass.devices || {})[deviceId];
+  return device ? device.name_by_user || device.name : null;
+}
+
+/* ------------------------------------------------------------------ */
+/* Base card                                                           */
+/* ------------------------------------------------------------------ */
+
+class RacklinkBaseCard extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+  }
+
+  setConfig(config) {
+    if (!config || !config.device_id) {
+      throw new Error("Set device_id to your RackLink PDU device");
+    }
+    this._config = config;
+    this._render();
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._render();
+  }
+
+  _call(domain, service, data) {
+    this._hass.callService(domain, service, data);
+  }
+
+  _moreInfo(entityId) {
+    const event = new CustomEvent("hass-more-info", {
+      bubbles: true,
+      composed: true,
+      detail: { entityId },
+    });
+    this.dispatchEvent(event);
+  }
+
+  _render() {
+    if (!this._config || !this._hass) return;
+    const model = collectModel(this._hass, this._config.device_id);
+    this.shadowRoot.innerHTML = `<style>${this._styles()}</style>${this._template(
+      model
+    )}`;
+    this._bind(model);
+  }
+
+  _styles() {
+    return `
+      ha-card { padding: 12px 16px 16px; }
+      .header {
+        display: flex; align-items: baseline; justify-content: space-between;
+        padding: 4px 0 8px;
+      }
+      .title { font-size: 1.25rem; font-weight: 500; }
+      .headline { font-size: 1.25rem; font-weight: 500; color: var(--primary-color); }
+      .chips { display: flex; flex-wrap: wrap; gap: 8px; padding-bottom: 8px; }
+      .chip {
+        background: var(--secondary-background-color);
+        border-radius: 12px; padding: 4px 10px; font-size: 0.85rem;
+        color: var(--secondary-text-color); cursor: pointer;
+      }
+      .chip b { color: var(--primary-text-color); font-weight: 500; }
+      .row {
+        display: flex; align-items: center; gap: 12px;
+        padding: 6px 0; border-top: 1px solid var(--divider-color);
+      }
+      .row .grow { flex: 1; min-width: 0; }
+      .row .name { font-weight: 500; cursor: pointer; }
+      .row .meta { font-size: 0.8rem; color: var(--secondary-text-color); }
+      .dot {
+        width: 10px; height: 10px; border-radius: 50%;
+        background: var(--disabled-color, #9e9e9e); flex: none;
+      }
+      .dot.on { background: var(--success-color, #4caf50); }
+      .dot.off { background: var(--error-color, #f44336); }
+      button {
+        font: inherit; color: var(--primary-color);
+        background: none; border: 1px solid var(--primary-color);
+        border-radius: 8px; padding: 4px 10px; cursor: pointer;
+      }
+      button.icon { border: none; padding: 4px; font-size: 1rem; }
+      button.danger { color: var(--error-color); border-color: var(--error-color); }
+      button:disabled { opacity: 0.4; cursor: default; }
+      .toggle {
+        position: relative; width: 40px; height: 22px; flex: none;
+        border-radius: 11px; border: none; padding: 0; cursor: pointer;
+        background: var(--disabled-color, #9e9e9e); transition: background 0.2s;
+      }
+      .toggle.on { background: var(--primary-color); }
+      .toggle::after {
+        content: ""; position: absolute; top: 2px; left: 2px;
+        width: 18px; height: 18px; border-radius: 50%;
+        background: var(--card-background-color, #fff); transition: left 0.2s;
+      }
+      .toggle.on::after { left: 20px; }
+      .stepper { display: flex; align-items: center; gap: 8px; }
+      .stepper .value { min-width: 42px; text-align: center; font-weight: 500; }
+      .footer { display: flex; gap: 8px; padding-top: 10px; flex-wrap: wrap; }
+      .empty { color: var(--secondary-text-color); padding: 8px 0; }
+      .section { border-top: 1px solid var(--divider-color); margin-top: 4px; padding-top: 4px; }
+      .section-title {
+        font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em;
+        color: var(--secondary-text-color); padding: 4px 0;
+      }
+    `;
+  }
+
+  _toggleButton(entry, cls) {
+    const state = stateOf(this._hass, entry);
+    const on = state && state.state === "on";
+    const disabled =
+      !state || state.state === "unavailable" ? "disabled" : "";
+    return `<button class="toggle ${on ? "on" : ""} ${cls || ""}"
+      data-entity="${entry.entity_id}" data-action="toggle" ${disabled}
+      title="${entry.entity_id}"></button>`;
+  }
+
+  _bind() {
+    this.shadowRoot.querySelectorAll("[data-action]").forEach((el) => {
+      el.addEventListener("click", (ev) => {
+        ev.stopPropagation();
+        const { action, entity } = el.dataset;
+        if (action === "toggle") {
+          this._call("switch", "toggle", { entity_id: entity });
+        } else if (action === "press") {
+          this._call("button", "press", { entity_id: entity });
+        } else if (action === "step") {
+          const value = Number(el.dataset.value);
+          this._call("number", "set_value", { entity_id: entity, value });
+        } else if (action === "more-info") {
+          this._moreInfo(entity);
+        }
+      });
+    });
+  }
+
+  getCardSize() {
+    return 3;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* PDU overview card                                                   */
+/* ------------------------------------------------------------------ */
+
+class RacklinkPduCard extends RacklinkBaseCard {
+  static getConfigElement() {
+    return document.createElement("racklink-card-editor");
+  }
+
+  static getStubConfig(hass) {
+    return { device_id: firstDeviceOfIntegration(hass) };
+  }
+
+  _template(model) {
+    const title =
+      this._config.title ||
+      deviceName(this._hass, this._config.device_id) ||
+      "RackLink PDU";
+    const power = fmt(this._hass, model.pdu.power, 1);
+    const chips = [
+      ["Voltage", model.pdu.voltage, 1],
+      ["Current", model.pdu.current, 2],
+      ["Energy", model.pdu.energy, 2],
+      ["Power factor", model.pdu.power_factor, 2],
+    ]
+      .filter(([, entry]) => entry && fmt(this._hass, entry) !== null)
+      .map(
+        ([label, entry, digits]) => `
+          <span class="chip" data-action="more-info"
+                data-entity="${entry.entity_id}">
+            ${label} <b>${fmt(this._hass, entry, digits)}</b>
+          </span>`
+      )
+      .join("");
+
+    const outlets = [...model.outlets.entries()]
+      .sort(([a], [b]) => a - b)
+      .map(([number, bucket]) => this._outletRow(number, bucket))
+      .join("");
+
+    const footer = [];
+    if (model.cycleAll) {
+      footer.push(`<button class="danger" data-action="press"
+        data-entity="${model.cycleAll.entity_id}">Cycle all outlets</button>`);
+    }
+
+    return `
+      <ha-card>
+        <div class="header">
+          <span class="title">${title}</span>
+          ${
+            power !== null && model.pdu.power
+              ? `<span class="headline" data-action="more-info"
+                   data-entity="${model.pdu.power.entity_id}">${power}</span>`
+              : ""
+          }
+        </div>
+        <div class="chips">${chips}</div>
+        ${outlets || '<div class="empty">No outlets found for this device.</div>'}
+        ${footer.length ? `<div class="footer">${footer.join("")}</div>` : ""}
+      </ha-card>
+    `;
+  }
+
+  _outletRow(number, bucket) {
+    if (!bucket.switch) return "";
+    const state = stateOf(this._hass, bucket.switch);
+    const on = state && state.state === "on";
+    const unavailable = !state || state.state === "unavailable";
+    const name =
+      (state && (state.attributes.outlet_name || state.attributes.friendly_name)) ||
+      `Outlet ${number}`;
+    const metaParts = [];
+    const power = fmt(this._hass, bucket.power, 1);
+    if (power !== null) metaParts.push(power);
+    const current = fmt(this._hass, bucket.current, 2);
+    if (current !== null) metaParts.push(current);
+    const nonCriticalState = stateOf(this._hass, bucket.nonCritical);
+    if (nonCriticalState && nonCriticalState.state === "on") {
+      metaParts.push("sheds");
+    }
+
+    return `
+      <div class="row">
+        <span class="dot ${unavailable ? "" : on ? "on" : "off"}"></span>
+        <div class="grow">
+          <div class="name" data-action="more-info"
+               data-entity="${bucket.switch.entity_id}">${number}. ${name}</div>
+          ${metaParts.length ? `<div class="meta">${metaParts.join(" · ")}</div>` : ""}
+        </div>
+        ${
+          bucket.cycle
+            ? `<button class="icon" title="Cycle outlet" data-action="press"
+                 data-entity="${bucket.cycle.entity_id}">&#8635;</button>`
+            : ""
+        }
+        ${this._toggleButton(bucket.switch)}
+      </div>
+    `;
+  }
+
+  getCardSize() {
+    if (!this._config || !this._hass) return 3;
+    return 2 + collectModel(this._hass, this._config.device_id).outlets.size;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Sequencer / load shedding card                                      */
+/* ------------------------------------------------------------------ */
+
+class RacklinkSequencerCard extends RacklinkBaseCard {
+  static getConfigElement() {
+    return document.createElement("racklink-card-editor");
+  }
+
+  static getStubConfig(hass) {
+    return { device_id: firstDeviceOfIntegration(hass) };
+  }
+
+  _template(model) {
+    const title =
+      this._config.title ||
+      `${deviceName(this._hass, this._config.device_id) || "RackLink"} power management`;
+
+    const sections = [];
+
+    if (model.sequence) {
+      const delay = model.sequenceDelay;
+      const delayState = stateOf(this._hass, delay);
+      const delayValue = delayState ? Number(delayState.state) : null;
+      const min = delayState ? Number(delayState.attributes.min) : 1;
+      const max = delayState ? Number(delayState.attributes.max) : 60;
+      sections.push(`
+        <div class="section">
+          <div class="section-title">Power-on sequencing</div>
+          <div class="row">
+            <div class="grow">
+              <div class="name" data-action="more-info"
+                   data-entity="${model.sequence.entity_id}">Outlet sequence</div>
+              <div class="meta">Staggers outlet power-on to avoid inrush current</div>
+            </div>
+            ${this._toggleButton(model.sequence)}
+          </div>
+          ${
+            delay && delayValue !== null && Number.isFinite(delayValue)
+              ? `<div class="row">
+                  <div class="grow">
+                    <div class="name" data-action="more-info"
+                         data-entity="${delay.entity_id}">Delay between outlets</div>
+                  </div>
+                  <div class="stepper">
+                    <button data-action="step" data-entity="${delay.entity_id}"
+                      data-value="${Math.max(min, delayValue - 1)}"
+                      ${delayValue <= min ? "disabled" : ""}>&minus;</button>
+                    <span class="value">${delayValue} s</span>
+                    <button data-action="step" data-entity="${delay.entity_id}"
+                      data-value="${Math.min(max, delayValue + 1)}"
+                      ${delayValue >= max ? "disabled" : ""}>+</button>
+                  </div>
+                </div>`
+              : ""
+          }
+        </div>
+      `);
+    }
+
+    if (model.loadShedding) {
+      const shedding = [...model.outlets.entries()]
+        .filter(([, bucket]) => {
+          const state = stateOf(this._hass, bucket.nonCritical);
+          return state && state.state === "on";
+        })
+        .map(([number, bucket]) => {
+          const state = stateOf(this._hass, bucket.switch);
+          const name =
+            (state &&
+              (state.attributes.outlet_name || state.attributes.friendly_name)) ||
+            `Outlet ${number}`;
+          return `${number}. ${name}`;
+        });
+      sections.push(`
+        <div class="section">
+          <div class="section-title">Load shedding</div>
+          <div class="row">
+            <div class="grow">
+              <div class="name" data-action="more-info"
+                   data-entity="${model.loadShedding.entity_id}">Load shedding</div>
+              <div class="meta">${
+                shedding.length
+                  ? `Powers off: ${shedding.join(", ")}`
+                  : "No outlets are marked non-critical on the PDU"
+              }</div>
+            </div>
+            ${this._toggleButton(model.loadShedding)}
+          </div>
+        </div>
+      `);
+    }
+
+    if (model.cycleAll) {
+      sections.push(`
+        <div class="section">
+          <div class="footer">
+            <button class="danger" data-action="press"
+              data-entity="${model.cycleAll.entity_id}">Cycle all outlets</button>
+          </div>
+        </div>
+      `);
+    }
+
+    return `
+      <ha-card>
+        <div class="header"><span class="title">${title}</span></div>
+        ${
+          sections.length
+            ? sections.join("")
+            : '<div class="empty">No sequencing or load shedding controls found. ' +
+              "These require the telnet channel (vendor features).</div>"
+        }
+      </ha-card>
+    `;
+  }
+
+  getCardSize() {
+    return 4;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Shared visual editor (device picker + title)                        */
+/* ------------------------------------------------------------------ */
+
+class RacklinkCardEditor extends HTMLElement {
+  setConfig(config) {
+    this._config = config;
+    this._render();
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    this._render();
+  }
+
+  _render() {
+    if (!this._hass || !this._config) return;
+    if (!this._form) {
+      this._form = document.createElement("ha-form");
+      this._form.computeLabel = (schema) =>
+        schema.name === "device_id" ? "PDU device" : "Title (optional)";
+      this._form.addEventListener("value-changed", (ev) => {
+        const config = { type: this._config.type, ...ev.detail.value };
+        this._config = config;
+        this.dispatchEvent(
+          new CustomEvent("config-changed", {
+            bubbles: true,
+            composed: true,
+            detail: { config },
+          })
+        );
+      });
+      this.appendChild(this._form);
+    }
+    this._form.hass = this._hass;
+    this._form.data = this._config;
+    this._form.schema = [
+      {
+        name: "device_id",
+        required: true,
+        selector: { device: { integration: DOMAIN } },
+      },
+      { name: "title", selector: { text: {} } },
+    ];
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Registration                                                        */
+/* ------------------------------------------------------------------ */
+
+if (!customElements.get("racklink-pdu-card")) {
+  customElements.define("racklink-pdu-card", RacklinkPduCard);
+}
+if (!customElements.get("racklink-sequencer-card")) {
+  customElements.define("racklink-sequencer-card", RacklinkSequencerCard);
+}
+if (!customElements.get("racklink-card-editor")) {
+  customElements.define("racklink-card-editor", RacklinkCardEditor);
+}
+
+window.customCards = window.customCards || [];
+if (!window.customCards.some((card) => card.type === "racklink-pdu-card")) {
+  window.customCards.push(
+    {
+      type: "racklink-pdu-card",
+      name: "RackLink PDU",
+      description:
+        "Overview and control of a Middle Atlantic RackLink PDU: live power " +
+        "metrics plus per-outlet switches and cycle buttons.",
+      preview: true,
+      documentationURL:
+        "https://github.com/mckay115/homeassistant-middleatlantic-racklink#dashboard-cards",
+    },
+    {
+      type: "racklink-sequencer-card",
+      name: "RackLink sequencer",
+      description:
+        "Manage RackLink outlet power-on sequencing, sequence delay, and " +
+        "load shedding.",
+      preview: true,
+      documentationURL:
+        "https://github.com/mckay115/homeassistant-middleatlantic-racklink#dashboard-cards",
+    }
+  );
+}

--- a/custom_components/middle_atlantic_racklink/manifest.json
+++ b/custom_components/middle_atlantic_racklink/manifest.json
@@ -3,7 +3,7 @@
   "name": "Middle Atlantic RackLink",
   "codeowners": ["@mckay115"],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["frontend", "http"],
   "documentation": "https://github.com/mckay115/homeassistant-middleatlantic-racklink",
   "import_executor": true,
   "integration_type": "device",
@@ -11,7 +11,7 @@
   "issue_tracker": "https://github.com/mckay115/homeassistant-middleatlantic-racklink/issues",
   "loggers": ["custom_components.middle_atlantic_racklink"],
   "requirements": [],
-  "version": "1.1.0",
+  "version": "1.2.0",
   "zeroconf": [
     {
       "type": "_http._tcp.local.",

--- a/custom_components/middle_atlantic_racklink/sensor.py
+++ b/custom_components/middle_atlantic_racklink/sensor.py
@@ -285,6 +285,7 @@ class RacklinkOutletSensor(RacklinkSensorBase):
             f"{coordinator.controller.pdu_serial}_outlet_{outlet}_{description.key}"
         )
         self._attr_translation_placeholders = {"outlet_number": str(outlet)}
+        self._attr_extra_state_attributes = {"outlet_number": outlet}
 
     @property
     def native_value(self) -> StateType:

--- a/custom_components/middle_atlantic_racklink/strings.json
+++ b/custom_components/middle_atlantic_racklink/strings.json
@@ -89,7 +89,7 @@
     },
     "binary_sensor": {
       "surge_protection": { "name": "Surge protection" },
-      "outlet_non_critical": { "name": "Outlet {outlet_number} sheds on load shedding" }
+      "outlet_non_critical": { "name": "Outlet {outlet_number} powers off during load shedding" }
     },
     "switch": {
       "outlet": { "name": "Outlet {outlet_number}" },

--- a/custom_components/middle_atlantic_racklink/translations/en.json
+++ b/custom_components/middle_atlantic_racklink/translations/en.json
@@ -89,7 +89,7 @@
     },
     "binary_sensor": {
       "surge_protection": { "name": "Surge protection" },
-      "outlet_non_critical": { "name": "Outlet {outlet_number} sheds on load shedding" }
+      "outlet_non_critical": { "name": "Outlet {outlet_number} powers off during load shedding" }
     },
     "switch": {
       "outlet": { "name": "Outlet {outlet_number}" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant-middleatlantic-racklink"
-version = "1.1.0"
+version = "1.2.0"
 description = "Home Assistant integration for Middle Atlantic RackLink PDUs with Redfish and Telnet support"
 readme = "README.md"
 authors = [{ name = "mckay115", email = "" }]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,6 +4,9 @@
 pytest-homeassistant-custom-component==0.13.316
 pytest-cov>=7.0.0
 
+# The integration depends on the frontend component (bundled dashboard cards)
+home-assistant-frontend
+
 # Lint and type-check tooling
 black>=25.0.0
 isort>=6.0.0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -15,6 +15,7 @@ from custom_components.middle_atlantic_racklink.exceptions import (
     RacklinkAuthenticationError,
 )
 from datetime import timedelta
+from homeassistant.components.frontend import DATA_EXTRA_MODULE_URL
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -34,6 +35,11 @@ async def test_setup_and_unload_entry(
     assert coordinator.system_data["voltage"] == 120.0
     assert coordinator.outlet_data[1]["state"] is True
     assert coordinator.status_data["surge_protection_ok"] is True
+
+    # The bundled dashboard cards are loaded on every dashboard
+    assert any(
+        "racklink-cards.js" in url for url in hass.data[DATA_EXTRA_MODULE_URL].urls
+    )
 
     assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds two custom Lovelace cards, bundled with and auto-registered by the integration — no manual resource configuration or separate frontend install needed. Also folds in the two pending PRs (#8 Node 24 action bumps, #9 load shedding sensor rename) and bumps the version to 1.2.0.

### Cards

[RackLink PDU and sequencer cards rendered in a dark dashboard](https://cursor.com/agents/bc-019f2608-ead6-706d-93fb-2c66d8a84742/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fracklink-cards.png)

- **`custom:racklink-pdu-card`** — PDU overview: total power headline, voltage/current/energy/power-factor chips, and one row per outlet with a state dot, custom outlet name, live power/current draw, a cycle button, and an on/off toggle. Outlets marked non-critical are tagged "sheds". Footer has a cycle-all action.
- **`custom:racklink-sequencer-card`** — power management: outlet sequence enable/disable with a delay stepper (bound to the sequence delay number entity), load shedding toggle with the list of outlets that will power off, and cycle-all. Shows a hint when vendor features (telnet) are unavailable.

Both cards:
- register in the card picker with a visual editor (device picker + optional title)
- discover entities via the device registry (`translation_key` based, with attribute fallbacks), so they survive entity renames
- are served from the integration at `/middle_atlantic_racklink/racklink-cards.js` and loaded via `add_extra_js_url` with a versioned cache-busting query

### Supporting changes

- `outlet_number` attribute added to per-outlet sensors, binary sensors, and cycle buttons so the cards can group entities per outlet
- Manifest now depends on `frontend` and `http`; `home-assistant-frontend` added to test requirements
- Includes #8 (checkout v6 / setup-python v6 / action-gh-release v3) and #9 (clearer "powers off during load shedding" sensor name)

## Testing

- 71 pytest tests pass (including a new assertion that the card module is registered with the frontend); mypy strict, black, isort, flake8, bandit, and hassfest all green
- Headless Chrome harness rendered both cards (screenshot above) and verified click-through behavior: outlet toggle, outlet cycle, cycle-all, sequence toggle, and delay stepper each dispatched the correct `switch.toggle` / `button.press` / `number.set_value` service calls

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2608-ead6-706d-93fb-2c66d8a84742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2608-ead6-706d-93fb-2c66d8a84742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

